### PR TITLE
handle case where initial file is a directory

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import {app, BrowserWindow, nativeImage, protocol} from "electron";
 import logger from "electron-log/main";
-import {closeWindow, createWindow, getAllWindows,openMainWindow} from "./windowManager";
+import {closeWindow, createWindow, getAllWindows, openMainWindow} from "./windowManager";
 import showOpenFileDialog from "./dialog/openFile";
 import {updateMenu} from "./menus/appMenu";
 import {addRecentFile, getStore} from "./store";
 import path from "path";
+import fs from "fs";
 import {updateColorScheme} from "./theme";
 import "./ipcHandler";
 import "dotenv/config";
@@ -44,7 +45,20 @@ app.on("ready", () => {
 
     logger.info("Arguments:", process.argv);
 
-    logger.info("Starting FeatherFlow with initial file:", initialFile);
+    if (initialFile) {
+        try {
+            const stats = fs.statSync(initialFile);
+            if (stats.isDirectory()) {
+                logger.error("Initial file is a directory, not a file:", initialFile);
+                initialFile = null; // Reset initialFile to prevent trying to open a directory
+            } else {
+                logger.info("Starting FeatherFlow with initial file:", initialFile);
+            }
+        } catch (err) {
+            logger.error("Failed to read initial file:", err);
+            initialFile = null;
+        }
+    }
 
     if (process.platform === "darwin") app.dock.setIcon(nativeImage.createFromPath(iconPath));
 


### PR DESCRIPTION
## Invalid Casing
Not sure about your use case, but this would not build on Arch Linux due to trying to open `.` (a directory). I'm unsure if this is OS specific, but I assume it must be considering it would've been working for you:
```
5495:0728/132217.226389:WARNING:bluez_dbus_manager.cc(248)] Floss manager not present, cannot set Floss enable/disable.
13:22:17.333 › Failed to read file: Error: EISDIR: illegal operation on a directory, read
[5532:0728/132219.963515:WARNING:sandbox_linux.cc(430)] InitializeSandbox() called with multiple threads in process gpu-process.
[5495:0728/132220.041326:INFO:CONSOLE(156)] "Setting  lineNumbers  to  true", source: file:///home/abbev/FeatherFlow/public/js/editor.js (156)
```
---
- Added check to verify if initialFile is a directory before attempting to open it.
- Log an error and reset initialFile to null if it is a directory.
- Ensure initialFile points to a valid file to prevent EISDIR error.